### PR TITLE
Missing redirect following.

### DIFF
--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -17,7 +17,7 @@ RUN update-ca-trust
 RUN mkdir lc
 WORKDIR /lc
 
-RUN curl https://downloads.limacharlie.io/sensor/linux/64 -o lc_sensor
+RUN curl -L https://downloads.limacharlie.io/sensor/linux/64 -o lc_sensor
 RUN chmod 500 ./lc_sensor
 
 CMD ./lc_sensor -d -


### PR DESCRIPTION
## Description of the change

The new download service uses redirects not followed by curl by default.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

